### PR TITLE
Add githubAuthToken to cast.yaml

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -37,6 +37,8 @@ if ! command -v cast &>/dev/null; then
   CAST_TARBALL="cast_${OS}_${ARCH}.tar.gz"
   fetch --log-level warn --repo https://github.com/riskalyze/cast --tag "~>1.0" --release-asset="${CAST_TARBALL}" --github-oauth-token "${GITHUB_OAUTH_TOKEN}" /tmp
   tar -xzf /tmp/"${CAST_TARBALL}" -C /usr/local/bin cast
+  
+  echo "githubAuthToken: ${GITHUB_OAUTH_TOKEN}" > "$HOME/.cast.yaml"
 fi
 
 bold "✨ Success! You are now ready to finish setting things up. Please run 'cast system install' to continue."


### PR DESCRIPTION
On first install of cast, save the Github PAT in `cast.yaml` for later use.