### PR TITLE
M1 fix

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -53,7 +53,7 @@ install /tmp/fetch /usr/local/bin/fetch
 
 (fetch --log-level warn --repo https://github.com/cli/cli --tag "~>1.0" --release-asset="gh_.*_macOS_amd64.tar.gz" /tmp) &
 spinner $!
-tar -xzf /tmp/gh_*_macOS_"${arch}".tar.gz --strip-components 2 -C /tmp
+tar -xzf /tmp/gh_*_macOS_amd64.tar.gz --strip-components 2 -C /tmp
 install /tmp/gh /usr/local/bin/gh
 
 echo "🎉 Great! Now, let's set up your GitHub account."

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -51,7 +51,7 @@ fi
 spinner $!
 install /tmp/fetch /usr/local/bin/fetch
 
-(fetch --log-level warn --repo https://github.com/cli/cli --tag "~>1.0" --release-asset="gh_.*_macOS_${arch}.tar.gz" /tmp) &
+(fetch --log-level warn --repo https://github.com/cli/cli --tag "~>1.0" --release-asset="gh_.*_macOS_amd64.tar.gz" /tmp) &
 spinner $!
 tar -xzf /tmp/gh_*_macOS_"${arch}".tar.gz --strip-components 2 -C /tmp
 install /tmp/gh /usr/local/bin/gh


### PR DESCRIPTION
## Background

Ran quickstart on an m1 laptop and rediscovered that `gh` only provides an `amd64` binary at this time... thankfully it's an easy fix.
