### PR TITLE
update to gh 2.0

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -51,7 +51,7 @@ fi
 spinner $!
 install /tmp/fetch /usr/local/bin/fetch
 
-(fetch --log-level warn --repo https://github.com/cli/cli --tag "~>1.0" --release-asset="gh_.*_macOS_amd64.tar.gz" /tmp) &
+(fetch --log-level warn --repo https://github.com/cli/cli --tag "~>2.0" --release-asset="gh_.*_macOS_amd64.tar.gz" /tmp) &
 spinner $!
 tar -xzf /tmp/gh_*_macOS_amd64.tar.gz --strip-components 2 -C /tmp
 install /tmp/gh /usr/local/bin/gh


### PR DESCRIPTION
## Background

gh 2.0 was [released](https://github.com/cli/cli/releases/tag/v2.0.0) with some nice features. Updating to it.

## Significant changes

- Update to gh 2.0

## Checklist

- [ ] Scripts have been run locally and work as expected.
- [ ] Docs have been reviewed and added / updated if needed.
- [ ] Shellcheck issues have been reviewed and fixed.
