### PR TITLE
Validate the user's GitHub token for required scopes

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -4,13 +4,15 @@
 set -eo pipefail
 
 arch=$(uname -m | sed 's/x86_64/amd64/')
-bold=$(tput bold)
-normal=$(tput sgr0)
 
+# Prints text in bold.
 bold() {
+  bold=$(tput bold)
+  normal=$(tput sgr0)
   echo "${bold}$1${normal}"
 }
 
+# Shows a spinner for longer-running tasks.
 spinner() {
   pid=$1
   spin='⣾⣽⣻⢿⡿⣟⣯⣷'
@@ -28,7 +30,7 @@ spinner() {
   return $?
 }
 
-# Print a friendly message if something fails
+# Prints a friendly message if something fails.
 function exit_handler {
   ret=$?
   if [ $ret -ne 0 ]; then
@@ -41,6 +43,7 @@ trap exit_handler EXIT
 bold "👋 Welcome! This script takes care of first-time setup of your computer."
 echo "🏁 First, let's install a couple of dependencies."
 
+# Make sure /usr/local/bin exists and has the correct permissions.
 if [ ! -d /usr/local/bin ]; then
   bold "📁 We need to create a /usr/local/bin folder. Please enter your password if prompted."
   sudo mkdir -p /usr/local/bin
@@ -51,10 +54,12 @@ if [ ! -O /usr/local/bin ]; then
   sudo chown -R "$(whoami):admin" /usr/local/bin
 fi
 
+# Install fetch so we can grab Github CLI and Cast from GitHub.
 (curl -o /tmp/fetch -sfSL "https://github.com/gruntwork-io/fetch/releases/download/v0.4.2/fetch_darwin_${arch}") &
 spinner $!
 install /tmp/fetch /usr/local/bin/fetch
 
+# Install the GitHub CLI.
 (fetch --log-level warn --repo https://github.com/cli/cli --tag "~>2.0" --release-asset="gh_.*_macOS_amd64.tar.gz" /tmp) &
 spinner $!
 tar -xzf /tmp/gh_*_macOS_amd64.tar.gz --strip-components 2 -C /tmp
@@ -62,19 +67,33 @@ install /tmp/gh /usr/local/bin/gh
 
 echo "🎉 Great! Now, let's set up your GitHub account."
 
+# Check the user's GitHub CLI auth status.
 if ! gh auth status &>/dev/null; then
+  # User is logged out or has never logged in before; we need to login.
   unset GITHUB_TOKEN
   gh auth login -s admin:public_key,read:packages -w
 fi
 
+# Fetch the user's PAT and validate its scopes.
+github_token=$(gh auth status -t 2> >(grep -oh 'gho.*'))
+scopes=$(curl --silent --location --request GET https://api.github.com --header "Authorization: token $github_token" --head | grep "x-oauth-scopes: ")
+for s in "admin:public_key" "gist" "read:org" "read:packages" "repo"; do
+  if [[ ! $scopes =~ $s ]]; then
+    # User is logged in but doesn't have all the right scopes; we need to refresh their token.
+    gh auth refresh -s admin:public_key,read:packages
+    github_token=$(gh auth status -t 2> >(grep -oh 'gho.*'))
+    break
+  fi
+done
+
 echo "🙌 Wonderful! GitHub is all set."
 echo "🧙 Next, let's install Cast (Riskalyze's multi-purpose dev tool)."
 
-github_token=$(gh auth status -t 2> >(grep -oh 'gho.*'))
+# Download and install Cast from the private GitHub repo.
 cast_gh_tarball="cast_darwin_${arch}.tar.gz"
 (fetch --log-level warn --repo https://github.com/riskalyze/cast --tag "~>1.0" --release-asset="${cast_gh_tarball}" --github-oauth-token "${github_token}" /tmp) &
 spinner $!
 tar -xzf "/tmp/${cast_gh_tarball}" -C /tmp
 install /tmp/cast /usr/local/bin/cast
 
-bold "✨  Success! You are now ready to finish setting things up. Please run 'cast system install' to continue."
+bold "✨ Success! You are now ready to finish setting things up. Please run 'cast system install' to continue."


### PR DESCRIPTION
## Background

Adds a step to validate that the user's GitHub token has all required scopes. This resolves a bug that can happen if the user already had the GitHub CLI installed and authenticated, but it lacked the correct scopes for downloading Cast.

## Significant changes

- Add step to validate token scope and run `gh auth refresh` if the token doesn't have sufficient scopes.
- Add a few comments to help delineate each step of the script.

## Checklist

- [x] Scripts have been run locally and work as expected.
- [ ] Docs have been reviewed and added / updated if needed.
- [x] Shellcheck issues have been reviewed and fixed.
