### PR TITLE
fix: Detect bad tokens and refresh if needed

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -78,6 +78,12 @@ fi
 
 # Fetch the user's PAT and validate its scopes.
 github_token=$(gh auth status -t 2> >(grep -oh 'gho.*'))
+
+if [ ! $github_token ]; then
+  gh auth refresh -s admin:public_key,read:packages
+  github_token=$(gh auth status -t 2> >(grep -oh 'gho.*'))
+fi
+
 scopes=$(curl --silent --location --request GET https://api.github.com --header "Authorization: token $github_token" --head | grep "x-oauth-scopes: ")
 for s in "admin:public_key" "gist" "read:org" "read:packages" "repo"; do
   if [[ ! $scopes =~ $s ]]; then


### PR DESCRIPTION
## Background

If the user had a very old token that didn't start with `gho` we would fail to detect the problem and other things would fail. This change makes sure we get a valid token (starting with `gho`) from `gh auth status`, otherwise we do a refresh.

## Significant changes

- Check for invalid token format and refresh if needed

## Checklist

- [x] Scripts have been run locally and work as expected.
- [ ] Docs have been reviewed and added / updated if needed.
- [ ] Shellcheck issues have been reviewed and fixed.
