### PR TITLE
fix: :bug: GithubCLI install fix

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -63,9 +63,9 @@ spinner $!
 install /tmp/fetch /usr/local/bin/fetch
 
 # Install the GitHub CLI.
-(fetch --log-level warn --repo https://github.com/cli/cli --tag "~>2.0" --release-asset="gh_.*_macOS_amd64.tar.gz" /tmp) &
+(fetch --log-level warn --repo https://github.com/cli/cli --tag "~>2.0" --release-asset="gh_.*_macOS_amd64.zip" /tmp) &
 spinner $!
-tar -xzf /tmp/gh_*_macOS_amd64.tar.gz --strip-components 2 -C /tmp
+tar -xzf /tmp/gh_*_macOS_amd64.zip --strip-components 2 -C /tmp
 install /tmp/gh /usr/local/bin/gh
 
 echo "🎉 Great! Now, let's set up your GitHub account."


### PR DESCRIPTION
Fixing github-cli install script

## Background

Github CLI release 2.2.8 do not longer support tar.gz package --> [Release info](https://github.com/cli/cli/releases/tag/v2.28.0#:~:text=%E2%9A%A0%EF%B8%8F,cannot%20be%20notarized.)

Changing to zip. Tested, works fine.

