### PR TITLE
feat(CODEOWNERS): update .github and infra codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,5 +3,7 @@
 ############################################################
 
 *                       @riskalyze/solo
+infra/                  @riskalyze/solo
+.github/                @riskalyze/solo
 .github/CODEOWNERS      @riskalyze/codeowners
 


### PR DESCRIPTION
## Background

This PR updates the `.github/CODEOWNERS` file to add `@riskalyze/solo` as code owners for the `infra/` and `.github/` directories. This change is part of a systematic effort to ensure the Solo team has appropriate oversight of infrastructure configuration (`infra/`) and GitHub workflow files (`.github/`) across all repositories in the organization.

This change helps establish consistent ownership patterns and ensures the right teams are automatically notified when changes are made to critical infrastructure and workflow configuration files.

## Significant changes

- Added `@riskalyze/solo` as code owners for `infra/` directory
- Added `@riskalyze/solo` as code owners for `.github/` directory

## Checklist

- [ ] Verify `@riskalyze/solo` team exists and has appropriate members
- [ ] Confirm this ownership structure aligns with organizational policy
- [ ] Validate that existing ownership rules (like `@riskalyze/codeowners` for the CODEOWNERS file itself) remain intact

---

**Link to Devin run:** https://app.devin.ai/sessions/d713f122967a4f9baa2a6e6b6fa59055  
**Requested by:** @montanapayne